### PR TITLE
wire up NdegTwistedCloverPreconditioned and get it to compile

### DIFF
--- a/include/dslash_quda.h
+++ b/include/dslash_quda.h
@@ -383,7 +383,7 @@ namespace quda {
      @param[in] x Vector field we accumulate onto to
      @param[in] parity Destination parity
      @param[in] dagger Whether this is for the dagger operator
-     @param[in] asymmetric Whether this is for the asymmetric preconditioned dagger operator (a*(1 - i*b*gamma_5) * D^dagger * in)
+     @param[in] asymmetric Whether this is for the asymmetric preconditioned dagger operator (a*(1 - i*b*gamma_5*tau3 + c*tau1) * D^dagger * in)
      @param[in] comm_override Override for which dimensions are partitioned
      @param[in] profile The TimeProfile used for profiling the dslash
   */
@@ -526,12 +526,14 @@ namespace quda {
      @param[in] x Vector field we accumulate onto to when xpay is true
      @param[in] parity Destination parity
      @param[in] dagger Whether this is for the dagger operator
+     @param[in] asymmetric Whether this is for the asymmetric preconditioned daggered operator
+      out = a * (C - i*b*gamma_5*tau_3 + c*tau_1)^{-1} * D^\dagger * in
      @param[in] comm_override Override for which dimensions are partitioned
      @param[in] profile The TimeProfile used for profiling the dslash
   */
   void ApplyNdegTwistedCloverPreconditioned(ColorSpinorField &out, const ColorSpinorField &in, const GaugeField &U,
       const CloverField &C, double a, double b, double c, bool xpay, const ColorSpinorField &x, int parity, bool dagger,
-      const int *comm_override, TimeProfile &profile);
+      bool asymmetric, const int *comm_override, TimeProfile &profile);
 
   /**
      @brief Driver for applying the Domain-wall 5-d stencil to a

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -57,7 +57,7 @@ set (QUDA_OBJS
   dslash_wilson_clover_preconditioned.cu 
   dslash_twisted_mass.cu dslash_twisted_mass_preconditioned.cu
   dslash_ndeg_twisted_mass.cu dslash_ndeg_twisted_mass_preconditioned.cu
-  dslash_ndeg_twisted_clover.cu #dslash_ndeg_twisted_clover_preconditioned.cu
+  dslash_ndeg_twisted_clover.cu dslash_ndeg_twisted_clover_preconditioned.cu
   dslash_twisted_clover.cu dslash_twisted_clover_preconditioned.cu
   dslash_wilson_clover_hasenbusch_twist.cu
   dslash_wilson_clover_hasenbusch_twist_preconditioned.cu

--- a/lib/dirac_twisted_clover.cpp
+++ b/lib/dirac_twisted_clover.cpp
@@ -216,7 +216,7 @@ namespace quda {
         flops += (1320ll + 552ll) * in.Volume();
       } else {
         ApplyNdegTwistedCloverPreconditioned(out, in, *gauge, *clover, 1.0, -2.0 * kappa * mu, 2.0 * kappa * epsilon,
-                                             false, in, parity, dagger, commDim, profile);
+                                             false, in, parity, dagger, !symmetric, commDim, profile);
         // FIXME check flops
         flops += (1320ll + 96ll + 48ll + 552ll) * in.Volume();
       } 


### PR DESCRIPTION
@urbach didn't want to step on your toes so I did this in a separate branch tonight, just wanted to see if I could get the logic compiled to get `NdegTwistedCloverPreconditioned` under test coverage.

Note that part of the non-deg twisted clover dslash already passes the  `tmc_ndeg_dslash` test, since the daggered symmetric operator is not fused and implemented via the Wilson Dslash and TwistCloverInv, the latter of which I generalised to two flavours yesterday.

See `lib/dirac_twisted_clover.cpp`:

```{C++}
  // apply hopping term, then inverse twist: (A_ee^-1 D_eo) or (A_oo^-1 D_oe),
  // and likewise for dagger: (D^dagger_eo D_ee^-1) or (D^dagger_oe A_oo^-1)
  void DiracTwistedCloverPC::Dslash(ColorSpinorField &out, const ColorSpinorField &in, const QudaParity parity) const
  {
    checkParitySpinor(in, out);
    checkSpinorAlias(in, out);

    if (in.TwistFlavor() != out.TwistFlavor())
      errorQuda("Twist flavors %d %d don't match", in.TwistFlavor(), out.TwistFlavor());
    if (in.TwistFlavor() == QUDA_TWIST_NO || in.TwistFlavor() == QUDA_TWIST_INVALID)
      errorQuda("Twist flavor not set %d", in.TwistFlavor());

    bool symmetric = (matpcType == QUDA_MATPC_EVEN_EVEN || matpcType == QUDA_MATPC_ODD_ODD) ? true : false;
    if (dagger && symmetric && !reverse) {
      bool reset = newTmp(&tmp2, in);
      TwistCloverInv(*tmp2, in, 1 - parity);
      DiracWilson::Dslash(out, *tmp2, parity);
      deleteTmp(&tmp2, reset);
    } else {
      if (in.TwistFlavor() == QUDA_TWIST_SINGLET){
        ApplyTwistedCloverPreconditioned(out, in, *gauge, *clover, 1.0, -2.0 * kappa * mu, false, in, parity, dagger,
                                         commDim, profile);
        flops += (1320ll + 552ll) * in.Volume();
      } else {
        ApplyNdegTwistedCloverPreconditioned(out, in, *gauge, *clover, 1.0, -2.0 * kappa * mu, 2.0 * kappa * epsilon,
                                             false, in, parity, dagger, !symmetric, commDim, profile);
        // FIXME check flops
        flops += (1320ll + 96ll + 48ll + 552ll) * in.Volume();
      } 
    }
  }
```

The logic for this split is also further spelled out in the Doxygen for `ApplyNdegTwistedCloverPreconditioned` (`include/dslash_quda.h`)

```
494   /**
495      @brief Driver for applying the non-degenerate preconditioned twisted-clover stencil
496 
497      out = a * (C + i*b*gamma_5*tau_3 - c*tau_1)^{-1} * D * in + x
498          = a * (C - i*b*gamma_5*tau_3 + c*tau_1)/(C^2 + b^2 - c^2) * D * in + x
499          = A^{-1} * D * in + x
500 
501      where D is the gauged Wilson linear operator and C is the clover
502      field.  This operator can (at present) be applied to only single
503      parity (checker-boarded) fields.  When the dagger operator is
504      requested, we do not transpose the order of operations, e.g.
505 
506      out = A^{-\dagger} D^\dagger  (no xpay term)
507 
508      Although not a conjugate transpose of the regular operator, this
509      variant is used to enable kernel fusion between the application
510      of D and the subsequent application of A, e.g., in the symmetric
511      dagger operator we need to apply
512 
513      M = (1 - kappa^2 D^{\dagger} A^{-\dagger} D{^\dagger} A^{-\dagger} )
514 
515      and since cannot fuse D{^\dagger} A^{-\dagger}, we instead fused
516      A^{-\dagger} D{^\dagger}.
517 
518      @param[out] out The output result field
519      @param[in] in The input field
520      @param[in] U The gauge field used for the operator
521      @param[in] C The clover field used for the operator
522      @param[in] a Scale factor applied to Wilson term ( typically 1.0)
523      @param[in] b chiral twist factor applied (typically -2*kappa*mu)
524      @param[in] c flavor twist factor applied (typically 2*kappa*epsilon)
525      @param[in] xpay Whether to do xpay or not
526      @param[in] x Vector field we accumulate onto to when xpay is true
527      @param[in] parity Destination parity
528      @param[in] dagger Whether this is for the dagger operator
529      @param[in] asymmetric Whether this is for the asymmetric preconditioned daggered operator
530       out = a * (C - i*b*gamma_5*tau_3 + c*tau_1)^{-1} * D^\dagger * in
531      @param[in] comm_override Override for which dimensions are partitioned
532      @param[in] profile The TimeProfile used for profiling the dslash
533   */
534   void ApplyNdegTwistedCloverPreconditioned(ColorSpinorField &out, const ColorSpinorField &in, const GaugeField &U,
535       const CloverField &C, double a, double b, double c, bool xpay, const ColorSpinorField &x, int parity, bool dagger,
536       bool asymmetric, const int *comm_override, TimeProfile &profile);
```

