### PR TITLE
closely follow how the PC twisted clover operator is called, avoiding…

### DIFF
--- a/include/dslash_quda.h
+++ b/include/dslash_quda.h
@@ -526,15 +526,13 @@ namespace quda {
      @param[in] x Vector field we accumulate onto to when xpay is true
      @param[in] parity Destination parity
      @param[in] dagger Whether this is for the dagger operator
-     @param[in] asymmetric Whether this is for the asymmetric preconditioned daggered operator
-      out = a * (C - i*b*gamma_5*tau_3 + c*tau_1)^{-1} * D^\dagger * in
      @param[in] comm_override Override for which dimensions are partitioned
      @param[in] profile The TimeProfile used for profiling the dslash
   */
   void ApplyNdegTwistedCloverPreconditioned(ColorSpinorField &out, const ColorSpinorField &in, const GaugeField &U,
                                             const CloverField &C, double a, double b, double c, bool xpay,
                                             const ColorSpinorField &x, int parity, bool dagger,
-                                            bool asymmetric, const int *comm_override, TimeProfile &profile);
+                                            const int *comm_override, TimeProfile &profile);
 
   /**
      @brief Driver for applying the Domain-wall 5-d stencil to a

--- a/include/kernels/dslash_ndeg_twisted_clover_preconditioned.cuh
+++ b/include/kernels/dslash_ndeg_twisted_clover_preconditioned.cuh
@@ -8,12 +8,11 @@
 namespace quda
 {
   
-  template <typename Float, int nColor, int nDim, QudaReconstructType reconstruct_, bool asymmetric_>
+  template <typename Float, int nColor, int nDim, QudaReconstructType reconstruct_>
     struct NdegTwistedCloverPreconditionedArg : WilsonArg<Float, nColor, nDim, reconstruct_> {
     using WilsonArg<Float, nColor, nDim, reconstruct_>::nSpin;
     static constexpr int length = (nSpin / (nSpin / 2)) * 2 * nColor * nColor * (nSpin / 2) * (nSpin / 2) / 2;
     static constexpr bool dynamic_clover = dynamic_clover_inverse();
-    static constexpr bool asymmetric = asymmetric_;
     
     typedef typename mapper<Float>::type real;
     typedef typename clover_mapper<Float, length>::type C;
@@ -48,7 +47,8 @@ namespace quda
   
   /**
      @brief Apply the preconditioned twisted-clover dslash
-       out(x) = M*in = x + a*(C + i*b*gamma_5*tau_3 + c*tau_1)/(C^2 + b^2 - c^2)*D*x
+       out(x) = M*in = a*(C + i*b*gamma_5*tau_3 + c*tau_1)/(C^2 + b^2 - c^2)*D*x ( xpay == false )
+       out(x) = M*in = in + a*(C + i*b*gamma_5*tau_3 + c*tau_1)/(C^2 + b^2 - c^2)*D*x ( xpay == true )
      Note this routine only exists in xpay form.
   */
     __device__ __host__ inline void operator()(int idx, int flavor, int parity)

--- a/include/kernels/dslash_ndeg_twisted_clover_preconditioned.cuh
+++ b/include/kernels/dslash_ndeg_twisted_clover_preconditioned.cuh
@@ -51,7 +51,6 @@ namespace quda
      @brief Apply the preconditioned twisted-clover dslash
        out(x) = M*in = a*(C + i*b*gamma_5*tau_3 + c*tau_1)/(C^2 + b^2 - c^2)*D*x ( xpay == false )
        out(x) = M*in = in + a*(C + i*b*gamma_5*tau_3 + c*tau_1)/(C^2 + b^2 - c^2)*D*x ( xpay == true )
-     Note this routine only exists in xpay form.
   */
     __device__ __host__ inline void operator()(int idx, int flavor, int parity)
     {

--- a/include/kernels/dslash_ndeg_twisted_clover_preconditioned.cuh
+++ b/include/kernels/dslash_ndeg_twisted_clover_preconditioned.cuh
@@ -34,6 +34,8 @@ namespace quda
       b(dagger ? -0.5 * b : 0.5 * b), // if dagger flip the chiral twist
       c(0.5*c)
       {
+        checkPrecision(U, A);
+        checkLocation(U, A);
       }
   };
 
@@ -118,7 +120,7 @@ namespace quda
         tmp.toNonRel(); // switch back to non-chiral basis
 
         if (xpay) {
-          Vector x = arg.x(coord.x_cb, my_spinor_parity);
+          Vector x = arg.x(my_flavor_idx, my_spinor_parity);
           out = x + arg.a * tmp;
         } else {
           // multiplication with a needed here?

--- a/lib/dirac_twisted_clover.cpp
+++ b/lib/dirac_twisted_clover.cpp
@@ -216,7 +216,7 @@ namespace quda {
         flops += (1320ll + 552ll) * in.Volume();
       } else {
         ApplyNdegTwistedCloverPreconditioned(out, in, *gauge, *clover, 1.0, -2.0 * kappa * mu, 2.0 * kappa * epsilon,
-                                             false, in, parity, dagger, !symmetric, commDim, profile);
+                                             false, in, parity, dagger, commDim, profile);
         // FIXME check flops
         flops += (1320ll + 96ll + 48ll + 552ll) * in.Volume();
       } 
@@ -247,7 +247,7 @@ namespace quda {
         flops += (1320ll + 552ll) * in.Volume();
       } else {
         ApplyNdegTwistedCloverPreconditioned(out, in, *gauge, *clover, 1.0, -2.0 * kappa * mu, 2.0 * kappa * epsilon,
-                                             true, in, parity, dagger, !symmetric, commDim, profile);
+                                             true, in, parity, dagger, commDim, profile);
         // FIXME check flops
         flops += (1320ll + 96ll + 48ll + 552ll) * in.Volume();
       }

--- a/lib/dirac_twisted_clover.cpp
+++ b/lib/dirac_twisted_clover.cpp
@@ -246,7 +246,7 @@ namespace quda {
             out, in, *gauge, *clover, k, -2.0 * kappa * mu, true, x, parity, dagger, commDim, profile);
         flops += (1320ll + 552ll) * in.Volume();
       } else {
-        ApplyNdegTwistedCloverPreconditioned(out, in, *gauge, *clover, 1.0, -2.0 * kappa * mu, 2.0 * kappa * epsilon,
+        ApplyNdegTwistedCloverPreconditioned(out, in, *gauge, *clover, k, -2.0 * kappa * mu, 2.0 * kappa * epsilon,
                                              true, in, parity, dagger, commDim, profile);
         // FIXME check flops
         flops += (1320ll + 96ll + 48ll + 552ll) * in.Volume();

--- a/lib/dirac_twisted_clover.cpp
+++ b/lib/dirac_twisted_clover.cpp
@@ -309,28 +309,22 @@ namespace quda {
 
     TwistCloverInv(symmetric ? *src : *tmp1, odd_bit ? b.Even() : b.Odd(), odd_bit ? QUDA_EVEN_PARITY : QUDA_ODD_PARITY);
 
-    // we desire solution to full system
-    if (b.TwistFlavor() == QUDA_TWIST_SINGLET) {
+    if (matpcType == QUDA_MATPC_EVEN_EVEN) {
+      // src = A_ee^-1 (b_e + k D_eo A_oo^-1 b_o)
+      DiracWilson::DslashXpay(*tmp1, *src, QUDA_EVEN_PARITY, b.Even(), kappa);
+    } else if (matpcType == QUDA_MATPC_ODD_ODD) {
+      // src = A_oo^-1 (b_o + k D_oe A_ee^-1 b_e)
+      DiracWilson::DslashXpay(*tmp1, *src, QUDA_ODD_PARITY, b.Odd(), kappa);
+    } else if (matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) {
+      // src = b_e + k D_eo A_oo^-1 b_o
+      DiracWilson::DslashXpay(*src, *tmp1, QUDA_EVEN_PARITY, b.Even(), kappa);
+    } else if (matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
+      // src = b_o + k D_oe A_ee^-1 b_e
+      DiracWilson::DslashXpay(*src, *tmp1, QUDA_ODD_PARITY, b.Odd(), kappa);
+    } else {
+      errorQuda("MatPCType %d not valid for DiracTwistedCloverPC", matpcType);
+    }
 
-      if (matpcType == QUDA_MATPC_EVEN_EVEN) {
-        // src = A_ee^-1 (b_e + k D_eo A_oo^-1 b_o)
-        DiracWilson::DslashXpay(*tmp1, *src, QUDA_EVEN_PARITY, b.Even(), kappa);
-      } else if (matpcType == QUDA_MATPC_ODD_ODD) {
-        // src = A_oo^-1 (b_o + k D_oe A_ee^-1 b_e)
-        DiracWilson::DslashXpay(*tmp1, *src, QUDA_ODD_PARITY, b.Odd(), kappa);
-      } else if (matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) {
-        // src = b_e + k D_eo A_oo^-1 b_o
-        DiracWilson::DslashXpay(*src, *tmp1, QUDA_EVEN_PARITY, b.Even(), kappa);
-      } else if (matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
-        // src = b_o + k D_oe A_ee^-1 b_e
-        DiracWilson::DslashXpay(*src, *tmp1, QUDA_ODD_PARITY, b.Odd(), kappa);
-      } else {
-        errorQuda("MatPCType %d not valid for DiracTwistedCloverPC", matpcType);
-      }
-
-    } else { // doublet:
-      errorQuda("Non-degenerate operator is not implemented");
-    } // end of doublet
 
     if (symmetric) TwistCloverInv(*src, *tmp1, odd_bit ? QUDA_ODD_PARITY : QUDA_EVEN_PARITY);
 
@@ -349,20 +343,15 @@ namespace quda {
     bool reset = newTmp(&tmp1, b.Even());
     int odd_bit = (matpcType == QUDA_MATPC_ODD_ODD || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) ? 1 : 0;
 
-    // create full solution
-    if (b.TwistFlavor() == QUDA_TWIST_SINGLET) {
-      if (matpcType == QUDA_MATPC_EVEN_EVEN || matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) {
-        // x_o = A_oo^-1 (b_o + k D_oe x_e)
-        DiracWilson::DslashXpay(*tmp1, x.Even(), QUDA_ODD_PARITY, b.Odd(), kappa);
-      } else if (matpcType == QUDA_MATPC_ODD_ODD ||   matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
-        // x_e = A_ee^-1 (b_e + k D_eo x_o)
-        DiracWilson::DslashXpay(*tmp1, x.Odd(), QUDA_EVEN_PARITY, b.Even(), kappa);
-      } else {
-        errorQuda("MatPCType %d not valid for DiracTwistedCloverPC", matpcType);
-      }
-    } else { // twist doublet:
-      errorQuda("Non-degenerate operator is not implemented");
-    } // end of twist doublet...
+    if (matpcType == QUDA_MATPC_EVEN_EVEN || matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) {
+      // x_o = A_oo^-1 (b_o + k D_oe x_e)
+      DiracWilson::DslashXpay(*tmp1, x.Even(), QUDA_ODD_PARITY, b.Odd(), kappa);
+    } else if (matpcType == QUDA_MATPC_ODD_ODD ||   matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
+      // x_e = A_ee^-1 (b_e + k D_eo x_o)
+      DiracWilson::DslashXpay(*tmp1, x.Odd(), QUDA_EVEN_PARITY, b.Even(), kappa);
+    } else {
+      errorQuda("MatPCType %d not valid for DiracTwistedCloverPC", matpcType);
+    }
 
     TwistCloverInv(odd_bit ? x.Even() : x.Odd(), *tmp1, odd_bit ? QUDA_EVEN_PARITY : QUDA_ODD_PARITY);
     deleteTmp(&tmp1, reset);

--- a/lib/dirac_twisted_clover.cpp
+++ b/lib/dirac_twisted_clover.cpp
@@ -247,7 +247,7 @@ namespace quda {
         flops += (1320ll + 552ll) * in.Volume();
       } else {
         ApplyNdegTwistedCloverPreconditioned(out, in, *gauge, *clover, k, -2.0 * kappa * mu, 2.0 * kappa * epsilon,
-                                             true, in, parity, dagger, commDim, profile);
+                                             true, x, parity, dagger, commDim, profile);
         // FIXME check flops
         flops += (1320ll + 96ll + 48ll + 552ll) * in.Volume();
       }

--- a/tests/host_reference/clover_reference.cpp
+++ b/tests/host_reference/clover_reference.cpp
@@ -600,8 +600,8 @@ void tmc_ndeg_matpc(void *out, void **gauge, void *in, void *clover, void *cInv,
     wil_dslash(tmp2, gauge, in2, 0, dagger, precision, gauge_param);
     ndegTwistCloverGamma5(tmptmp1, tmptmp2, tmp1, tmp2, clover, cInv,
                           dagger, kappa, mu, epsilon, 0, QUDA_TWIST_GAMMA5_INVERSE, precision);
-    wil_dslash(out1, gauge, tmp1, 1, dagger, precision, gauge_param);
-    wil_dslash(out2, gauge, tmp2, 1, dagger, precision, gauge_param);
+    wil_dslash(out1, gauge, tmptmp1, 1, dagger, precision, gauge_param);
+    wil_dslash(out2, gauge, tmptmp2, 1, dagger, precision, gauge_param);
     ndegTwistCloverGamma5(tmp1, tmp2, in1, in2, clover, cInv, dagger,
                           kappa, mu, epsilon, 1, QUDA_TWIST_GAMMA5_DIRECT, precision);
     xpay(tmp1, kappa2, out1, Vh * spinor_site_size, precision);


### PR DESCRIPTION
… the complexities related to the triviality of the inverse of the diagonal term of the twisted mass operator, which is not relevant for the twisted-clover operator

This gets us closer to the operator working as intended. I don't think that the type traits that prevented instantiation for particular combinations of the non-deg twisted mass operator are necessary here as the inverse of the diagonal is not trivial and cannot simply be applied via the the "TM" version of the Wilson operator.