### PR TITLE
add 'tm_rho' parameter for Hasenbusch mass preconditioning for twiste…

### DIFF
--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -46,6 +46,8 @@ namespace quda {
     cudaGaugeField *xInvKD; // used for the Kahler-Dirac operator only
 
     double mu; // used by twisted mass only
+    double tm_rho; // "rho"-type Hasenbusch mass used for twisted clover (like regular rho but
+                   // applied like a twisted mass and ignored in the inverse)
     double mu_factor; // used by multigrid only
     double epsilon; //2nd tm parameter (used by twisted mass only)
 
@@ -72,6 +74,7 @@ namespace quda {
       gauge(0),
       clover(0),
       mu(0.0),
+      tm_rho(0.0),
       mu_factor(0.0),
       epsilon(0.0),
       tmp1(0),
@@ -99,6 +102,7 @@ namespace quda {
       printfQuda("matpcType = %d\n", matpcType);
       printfQuda("dagger = %d\n", dagger);
       printfQuda("mu = %g\n", mu);
+      printfQuda("tm_rho = %g\n", tm_rho);
       printfQuda("epsilon = %g\n", epsilon);
       printfQuda("halo_precision = %d\n", halo_precision);
       for (int i=0; i<QUDA_MAX_DIM; i++) printfQuda("commDim[%d] = %d\n", i, commDim[i]);
@@ -1038,6 +1042,7 @@ public:
 
   protected:
     double mu;
+    double tm_rho;
     double epsilon;
     cudaCloverField *clover;
     void checkParitySpinor(const ColorSpinorField &, const ColorSpinorField &) const;

--- a/include/quda.h
+++ b/include/quda.h
@@ -128,6 +128,7 @@ extern "C" {
     double mq3;
 
     double mu;    /**< Twisted mass parameter */
+    double tm_rho; /**< Hasenbusch mass shift applied like twisted mass to diagonal (but not inverse) */
     double epsilon; /**< Twisted mass parameter */
 
     QudaTwistFlavorType twist_flavor;  /**< Twisted mass flavor */

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -342,6 +342,8 @@ void printQudaInvertParam(QudaInvertParam *param) {
   P(m5, INVALID_DOUBLE);
   P(Ls, INVALID_INT);
   P(mu, INVALID_DOUBLE);
+  P(epsilon, INVALID_DOUBLE);
+  P(tm_rho, INVALID_DOUBLE);
   P(twist_flavor, QUDA_TWIST_INVALID);
   P(laplace3D, INVALID_INT);
 #else
@@ -359,9 +361,15 @@ void printQudaInvertParam(QudaInvertParam *param) {
     P(m5, INVALID_DOUBLE);
     P(Ls, INVALID_INT);
   }
-  if (param->dslash_type == QUDA_TWISTED_MASS_DSLASH) {
+  if (param->dslash_type == QUDA_TWISTED_MASS_DSLASH || param->dslash_type == QUDA_TWISTED_CLOVER_DSLASH) {
     P(mu, INVALID_DOUBLE);
     P(twist_flavor, QUDA_TWIST_INVALID);
+  }
+  if (param->dslash_type == QUDA_TWISTED_CLOVER_DSLASH){
+    P(tm_rho, INVALID_DOUBLE);
+  }
+  if (param->twist_flavor == QUDA_TWIST_NONDEG_DOUBLET){
+    P(epsilon, INVALID_DOUBLE);
   }
 #endif
 

--- a/lib/dirac_twisted_clover.cpp
+++ b/lib/dirac_twisted_clover.cpp
@@ -10,6 +10,7 @@ namespace quda {
     DiracWilson(param, nDim),
     mu(param.mu),
     epsilon(param.epsilon),
+    tm_rho(param.tm_rho),
     clover(param.clover)
   {
   }
@@ -17,6 +18,7 @@ namespace quda {
   DiracTwistedClover::DiracTwistedClover(const DiracTwistedClover &dirac) :
     DiracWilson(dirac),
     mu(dirac.mu),
+    tm_rho(dirac.tm_rho),
     epsilon(dirac.epsilon),
     clover(dirac.clover)
   {
@@ -77,8 +79,10 @@ namespace quda {
   {
 
     if (in.TwistFlavor() == QUDA_TWIST_SINGLET) {
-      // k * D * in + (A + i*2*mu*kappa*gamma_5) *x
-      ApplyTwistedClover(out, in, *gauge, *clover, k, 2 * mu * kappa, x, parity, dagger, commDim, profile);
+      // k * D * in + (A + i*2*(mu+tm_rho)*kappa*gamma_5) *x
+      // tm_rho is a Hasenbusch mass preconditioning parameter applied just like a twisted mass
+      // but *not* the inverse of M_ee or M_oo
+      ApplyTwistedClover(out, in, *gauge, *clover, k, 2 * (mu + tm_rho) * kappa, x, parity, dagger, commDim, profile);
       // wilson + chiral twist + clover
       flops += (1320ll + 48ll + 504ll) * in.Volume();
 
@@ -211,8 +215,8 @@ namespace quda {
       deleteTmp(&tmp2, reset);
     } else {
       if (in.TwistFlavor() == QUDA_TWIST_SINGLET){
-        ApplyTwistedCloverPreconditioned(out, in, *gauge, *clover, 1.0, -2.0 * kappa * mu, false, in, parity, dagger,
-                                         commDim, profile);
+        ApplyTwistedCloverPreconditioned(out, in, *gauge, *clover, 1.0, -2.0 * kappa * mu, false, in,
+                                         parity, dagger, commDim, profile);
         flops += (1320ll + 48ll + 504ll) * in.Volume();
       } else {
         ApplyNdegTwistedCloverPreconditioned(out, in, *gauge, *clover, 1.0, -2.0 * kappa * mu, 2.0 * kappa * epsilon,
@@ -241,8 +245,8 @@ namespace quda {
       deleteTmp(&tmp2, reset);
     } else {
       if(in.TwistFlavor() == QUDA_TWIST_SINGLET) {
-        ApplyTwistedCloverPreconditioned(out, in, *gauge, *clover, k, -2.0 * kappa * mu, true, x, parity, dagger,
-                                         commDim, profile);
+        ApplyTwistedCloverPreconditioned(out, in, *gauge, *clover, k, -2.0 * kappa * mu, true, x, parity,
+                                         dagger, commDim, profile);
         flops += (1320ll + 48ll + 504ll) * in.Volume();
       } else {
         ApplyNdegTwistedCloverPreconditioned(out, in, *gauge, *clover, k, -2.0 * kappa * mu, 2.0 * kappa * epsilon,

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1671,6 +1671,7 @@ namespace quda {
     diracParam.mass = inv_param->mass;
     diracParam.m5 = inv_param->m5;
     diracParam.mu = inv_param->mu;
+    diracParam.tm_rho = inv_param->tm_rho;
 
     for (int i=0; i<4; i++) diracParam.commDim[i] = 1;   // comms are always on
 


### PR DESCRIPTION
…d clover HMC using tmLQCD

@Marcogarofalo @sunpho84 After some more thought I realised that as far as I understand, we won't be able to rely on the `rho` parameter in the clover accessor for our purposes.

I've added a `tm_rho` parameter to QUDA which acts like a twisted mass in the diagonal of the asymetrically preconditioned twisted clover operator (but not in the inverse of the diagonal).

I think this doesn't break anything (unless one sets `tm_rho` non-zero). If it does break anything, the PR acceptance tests in the QUDA repo should uncover any breakage.